### PR TITLE
Added extended error message to fomosto export abort

### DIFF
--- a/apps/fomosto
+++ b/apps/fomosto
@@ -122,8 +122,8 @@ def cl_parse(command, args, setup=None):
     process_common_options(options)
     return parser, options, args
 
-def die(message):
-    sys.exit('%s: error: %s' % (program_name, message))
+def die(message, err=''):
+    sys.exit('%s: error: %s \n %s' % (program_name, message, err))
 
 def fomo_wrapper_module(name):
     try:
@@ -574,8 +574,8 @@ def command_export(args):
 
     try:
         from tunguska import gfdb
-    except ImportError:
-        die('the kiwi tools must be installed to use this feature')
+    except ImportError as err:
+        die('the kiwi tools must be installed to use this feature', err)
 
     def setup(parser):
         parser.add_option('--nchunks', dest='nchunks', type='int', 

--- a/src/snuffling.py
+++ b/src/snuffling.py
@@ -195,9 +195,9 @@ class Snuffling:
                 self._menu_parent.add_snuffling_help_menuitem(self._helpmenuitem)
 
     def set_force_panel(self, bool=True):
-        '''Force to create a panel
+        '''Force to create a panel.
 
-        :param bool: if ``True`` will create a panel with Help, Clear and Run button
+        :param bool: if ``True`` will create a panel with Help, Clear and Run button.
         '''
         self._force_panel = bool
 
@@ -498,6 +498,13 @@ class Snuffling:
         return self._parameters
    
     def get_parameter(self, ident):
+        '''Get one of the snuffling's adjustable parameter definitions.
+        
+        :param ident: identifier of the parameter
+
+        Returns an object of type :py:class:`Param` or ``None``.
+        '''
+
         for param in self._parameters:
             if param.ident == ident:
                 return param

--- a/src/snuffling.py
+++ b/src/snuffling.py
@@ -142,6 +142,7 @@ class Snuffling:
         self._no_viewer_pile = None 
         self._cli_params = {}
         self._filename = None
+        self._force_panel = False
 
 
     def setup(self):
@@ -192,6 +193,13 @@ class Snuffling:
 
             if self._helpmenuitem:
                 self._menu_parent.add_snuffling_help_menuitem(self._helpmenuitem)
+
+    def set_force_panel(self, bool=True):
+        '''Force to create a panel
+
+        :param bool: if ``True`` will create a panel with Help, Clear and Run button
+        '''
+        self._force_panel = bool
 
     def make_cli_parser1(self):
         import optparse
@@ -804,7 +812,7 @@ class Snuffling:
     
         params = self.get_parameters()
         self._param_controls = {}
-        if params:
+        if params or self._force_panel:
             sarea = MyScrollArea(parent.get_panel_parent_widget())
             sarea.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
             frame = MyFrame(sarea)
@@ -819,7 +827,7 @@ class Snuffling:
             frame.setLayout( layout )
             
             parlayout = QGridLayout()
-            
+
             irow = 0
             ipar = 0
             have_switches = False


### PR DESCRIPTION
Given that kiwi was properly installed but lacking dependency Cheetah or gmtpy it would fail only saying
   
    the kiwi tools must be installed to use this feature

This is kind of confusing. Now, fomosto is a bit more explicit as it now says e.g.
    
    fomosto: error: the kiwi tools must be installed to use this feature 
     No module named gmtpy



