### PR TITLE
pile: string of empty pile doesn't throw exception

### DIFF
--- a/src/gui_util.py
+++ b/src/gui_util.py
@@ -1,11 +1,14 @@
 import math, calendar, time, copy
 import numpy as num
+import logging
 
 import pyrocko.util, pyrocko.plot, pyrocko.model, pyrocko.trace, pyrocko.plot
 from pyrocko.util import TableWriter, TableReader
 
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *
+
+logger = logging.getLogger('pyrocko.gui_util.py')
 
 def gmtime_x(timestamp):
     etimestamp = float(num.floor(timestamp))

--- a/src/pile.py
+++ b/src/pile.py
@@ -1141,9 +1141,16 @@ class Pile(TracesGroup):
         return self.deltatmax
 
     def __str__(self):
+        if self.tmin!=None and self.tmax!=None:
+            tmin = util.time_to_str(self.tmin)
+            tmax = util.time_to_str(self.tmax)
+        else:
+            tmin = self.tmin
+            tmax = self.tmax
+
         s = 'Pile\n'
         s += 'number of subpiles: %i\n' % len(self.subpiles)
-        s += 'timerange: %s - %s\n' % (util.time_to_str(self.tmin), util.time_to_str(self.tmax))
+        s += 'timerange: %s - %s\n' % (tmin, tmax)
         s += 'networks: %s\n' % ', '.join(sl(self.networks.keys()))
         s += 'stations: %s\n' % ', '.join(sl(self.stations.keys()))
         s += 'locations: %s\n' % ', '.join(sl(self.locations.keys()))

--- a/src/pile.py
+++ b/src/pile.py
@@ -1141,23 +1141,23 @@ class Pile(TracesGroup):
         return self.deltatmax
 
     def __str__(self):
-        if self.tmin!=None and self.tmax!=None:
+        if self.tmin is not None and self.tmax is not None:
             tmin = util.time_to_str(self.tmin)
             tmax = util.time_to_str(self.tmax)
-        else:
-            tmin = self.tmin
-            tmax = self.tmax
+            s = 'Pile\n'
+            s += 'number of subpiles: %i\n' % len(self.subpiles)
+            s += 'timerange: %s - %s\n' % (tmin, tmax)
+            s += 'networks: %s\n' % ', '.join(sl(self.networks.keys()))
+            s += 'stations: %s\n' % ', '.join(sl(self.stations.keys()))
+            s += 'locations: %s\n' % ', '.join(sl(self.locations.keys()))
+            s += 'channels: %s\n' % ', '.join(sl(self.channels.keys()))
+            s += 'deltats: %s\n' % ', '.join(sl(self.deltats.keys()))
 
-        s = 'Pile\n'
-        s += 'number of subpiles: %i\n' % len(self.subpiles)
-        s += 'timerange: %s - %s\n' % (tmin, tmax)
-        s += 'networks: %s\n' % ', '.join(sl(self.networks.keys()))
-        s += 'stations: %s\n' % ', '.join(sl(self.stations.keys()))
-        s += 'locations: %s\n' % ', '.join(sl(self.locations.keys()))
-        s += 'channels: %s\n' % ', '.join(sl(self.channels.keys()))
-        s += 'deltats: %s\n' % ', '.join(sl(self.deltats.keys()))
+        else:
+            s = 'empty Pile'
+
         return s
-    
+
     def snuffle(self, **kwargs):
         '''Visualize it.
 


### PR DESCRIPTION
Creating and printing an empty pile caused this exception:

Traceback (most recent call last):
  File "parallel_pile.py", line 13, in <module>
    do_something_parallel('E', p)
  File "parallel_pile.py", line 6, in do_something_parallel
    print shared_pile
  File "/usr/local/lib/python2.7/dist-packages/pyrocko/pile.py", line 1146, in __str__
    s += 'timerange: %s - %s\n' % (util.time_to_str(self.tmin), util.time_to_str(self.tmax))
  File "/usr/local/lib/python2.7/dist-packages/pyrocko/util.py", line 613, in time_to_str
    t0 = math.floor(t)
TypeError: a float is required
