### PR TITLE
Osx setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -376,7 +376,6 @@ setup(
             'parstack_ext',
             include_dirs=[numpy.get_include()],
             libraries=extension_libs_parstack,
-            #libraries=['gomp'],
             extra_compile_args=extension_args_parstack,
             sources=[pjoin('src', 'parstack_ext.c')],
         )

--- a/setup.py
+++ b/setup.py
@@ -231,6 +231,7 @@ class custom_build_ext(build_ext):
     def run(self):
         make_prerequisites()
         build_ext.run(self)
+
 class custom_build_app(build_ext):
     def run(self):
         self.make_app()
@@ -279,6 +280,30 @@ class custom_build_app(build_ext):
 
         want_delete_dir = glob.glob("dist/Snuffler.app/Contents/Resources/lib/python2.7/matplotlib/test*")
         map(shutil.rmtree, want_delete_dir)
+
+
+def xcode_version_str():
+    from subprocess import Popen, PIPE
+    return Popen(['xcodebuild', '-version'], stdout=PIPE, shell=False)\
+        .communicate()[0].split()[1]
+
+def support_omp():
+    import platform
+    from distutils.version import StrictVersion
+    if platform.mac_ver() == ('', ('', '', ''), ''):
+        return True
+    else:
+        v = StrictVersion(xcode_version_str())
+        return v<StrictVersion('4.2.0')
+
+
+
+if support_omp():
+    extension_args_parstack = ['-fopenmp', '-O3', '-Wextra']
+    extension_libs_parstack = ['gomp']
+else:
+    extension_args_parstack = ['-Dnoomp', '-O3', '-Wextra']
+    extension_libs_parstack = []
 
 setup(
     cmdclass={
@@ -350,8 +375,9 @@ setup(
         Extension(
             'parstack_ext',
             include_dirs=[numpy.get_include()],
-            libraries=['gomp'],
-            extra_compile_args=['-fopenmp', '-O3', '-Wextra'],
+            libraries=extension_libs_parstack,
+            #libraries=['gomp'],
+            extra_compile_args=extension_args_parstack,
             sources=[pjoin('src', 'parstack_ext.c')],
         )
     ],

--- a/src/parstack_ext.c
+++ b/src/parstack_ext.c
@@ -6,7 +6,9 @@
 #include "numpy/arrayobject.h"
 
 #include <stdlib.h>
-#include <omp.h>
+#if !noomp
+# include <omp.h>
+#endif
 #include <stdio.h>
 
 #define CHUNKSIZE 10
@@ -55,6 +57,7 @@ double dmax(double a, double b) {
 #define SUCCESS 0
 #define NODATA 1
 #define INVALID 2
+#define OMPERROR 3
 
 int parstack_config(
         size_t narrays,
@@ -108,7 +111,9 @@ int parstack(
         double *result,
         int nparallel) {
 
-
+	#if noomp
+	    return OMPERROR;
+	#endif
     int imin, istart, ishift;
     size_t iarray, nsamp, i;
     double weight;

--- a/src/parstack_ext.c
+++ b/src/parstack_ext.c
@@ -110,6 +110,7 @@ int parstack(
         double *result,
         int nparallel) {
 
+	(void) nparallel;
     int imin, istart, ishift;
     size_t iarray, nsamp, i;
     double weight;


### PR DESCRIPTION
Wenn das system OSX und XCode juenger als 4.2. ist (ab da war clang default) wird omp ignoriert. 